### PR TITLE
Fixed handling of spaces in folder selection.

### DIFF
--- a/src/VivOAuthIMAP.php
+++ b/src/VivOAuthIMAP.php
@@ -212,7 +212,7 @@ class VivOAuthIMAP {
      * @return boolean
      */
     public function selectFolder($folder) {
-        $this->writeCommannd("A" . $this->codeCounter, "EXAMINE $folder");
+        $this->writeCommannd("A" . $this->codeCounter, "EXAMINE \"$folder\"");
         $response = $this->readResponse("A" . $this->codeCounter);
         if ($response[0][0] == "OK") {
             return true;


### PR DESCRIPTION
This was breaking the ability to select any IMAP folder with spaces in it, like [Gmail]All Mail 
